### PR TITLE
Make the timestamp generic.

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -126,8 +126,8 @@
 	}
 
 	@if $timestamp {
-		.o-editorial-typography-byline-timestamp {
-			@include oEditorialTypographyBylineTimestamp();
+		.o-editorial-typography-timestamp {
+			@include oEditorialTypographyTimestamp();
 		}
 	}
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -149,11 +149,12 @@
 	@include oTypographySans($scale: 0);
 }
 
-/// Output styles for the byline timestamp.
+/// Output styles for a timestamp.
 /// Font family and size are inherited from the
-/// parent element.
-/// @see oEditorialTypographyByline
-@mixin oEditorialTypographyBylineTimestamp() {
+/// parent element so this mixin may be used in
+/// multiple contexts. For example timestamps in
+/// a comment section or a byline.
+@mixin oEditorialTypographyTimestamp() {
 	text-transform: uppercase;
 	color: oColorsGetPaletteColor('black-60');
 }


### PR DESCRIPTION
The timestamp was made specific to the byline as that is it's main
use. Making it specific would have allowed for byline specific
updates to happen more freely. However the existing o-typography
timestamp mixin does have more uses. Notably in the new version
of o-comments. This commit renames the timestamp to make it
generic again.

Provided we successfully encourage users to use the primary mixin,
or successfully reintroduce Sass placeholders without issues, we
still have a route to modify byline timestamps independently of
other timestamps (without migration work) -- should we want to

```scss
@if $byline and $timestamp {
    .o-editorial-typography-byline > .o-editorial-typography-timestamp {
        color: hotpink;
    }
}
```

This undoes 686237c7e587c0224d8968e73c9d67c391134254