### PR TITLE
Include fonts in the same way as o-typography.

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -29,8 +29,7 @@
 	'author': true,
 	'topic': true,
 	'byline': true,
-	'timestamp': true,
-	'fonts': true,
+	'timestamp': true
 )) {
 	$body: map-get($opts, 'body');
 	$lists: map-get($opts, 'lists');
@@ -50,10 +49,14 @@
 	$topic: map-get($opts, 'topic');
 	$byline: map-get($opts, 'byline');
 	$timestamp: map-get($opts, 'timestamp');
-	$fonts: map-get($opts, 'fonts');
 
-	@if $fonts {
+	// Load fonts within the primary mixin in-case silent mode is on.
+	// Don't load fonts if o-typography has output them already since
+	// `$o-editorial-typography-load-fonts` was set.
+	@if $o-editorial-typography-load-fonts == true and $o-typography-load-fonts == false {
 		@include oFonts();
+		// Set to false so fonts are not output twice by o-editorial-typography.
+		$o-editorial-typography-load-fonts: false !global;
 	}
 
 	@if $body {

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -1,19 +1,4 @@
 @include describe('oEditorialTypography mixins') {
 	@include describe('oEditorialTypography') {
-		@include it('does something') {
-			@include assert() {
-				@include output($selector: false) {
-					.test-mixin {
-						@include oEditorialTypography();
-					}
-				};
-
-				@include expect($selector: false) {
-					.test-mixin .o-editorial-typography {
-						display: block;
-					}
-				};
-			};
-		}
 	}
 }


### PR DESCRIPTION
Introducing `$o-editorial-typography-load-fonts` means a user
doesn't need to configure a second time that they don't want fonts
included automatically; whilst also being able to use
o-editorial-typography without o-typography.