### PR TITLE
Update the primary mixin to support the output of a single heading.

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -41,7 +41,7 @@
 	$headline: map-get($opts, 'headline');
 	$headings: map-get($opts, 'headings');
 	$headings: if($headings, $headings, ());
-	@if($headings and type-of($headings) != 'list') {
+	@if($headings and type-of($headings) != 'list' and type-of($headings) != 'number') {
 		@error ('The "headings" option must be a list of heading levels to include e.g. `(1, 2, 3, 4, 5)`.');
 	}
 	$standfirst: map-get($opts, 'standfirst');

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -75,14 +75,13 @@
 	}
 
 	// undo browser defaults
-	font-weight: normal;
 	margin: 0;
 
 	// set color
 	color: oColorsByUsecase('body', 'text');
 
 	@if($level == 1) {
-		@include oTypographyDisplay($scale: (default: 4, S: 5, L: 6));
+		@include oTypographyDisplay($scale: (default: 4, S: 5, L: 6), $weight: 'regular');
 	}
 
 	@if($level == 2) {
@@ -90,15 +89,15 @@
 	}
 
 	@if($level == 3) {
-		@include oTypographySans($scale: 4);
+		@include oTypographySans($scale: 4, $weight: 'regular');
 	}
 
 	@if($level == 4) {
-		@include oTypographySans($scale: 3);
+		@include oTypographySans($scale: 3, $weight: 'regular');
 	}
 
 	@if($level == 5) {
-		@include oTypographySans($scale: 0);
+		@include oTypographySans($scale: 0, $weight: 'regular');
 		text-transform: uppercase;
 		letter-spacing: 0.5px;
 	}

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -1,4 +1,53 @@
 @include describe('oEditorialTypography mixins') {
+
+	@include test-module('oEditorialTypography') {
+		@include test('Can output styles for a single heading') {
+			@include assert {
+				@include output($selector: false) {
+					@include oEditorialTypography(('headings': (1)));
+				}
+				@include contains($selector: false) {
+					.o-editorial-typography-heading-level-1 {
+						font-weight: normal;
+						margin: 0;
+						color: #33302e;
+						font-family: FinancierDisplayWeb, serif;
+						font-size: 28px;
+						line-height: 32px;
+					}
+				}
+			}
+		}
+
+		@include test('Can output styles for multiple headings') {
+			@include assert {
+				@include output($selector: false) {
+					@include oEditorialTypography(('headings': (1, 2)));
+				}
+				@include contains($selector: false) {
+					.o-editorial-typography-heading-level-1 {
+						font-weight: normal;
+						margin: 0;
+						color: #33302e;
+						font-family: FinancierDisplayWeb, serif;
+						font-size: 28px;
+						line-height: 32px;
+					}
+
+					.o-editorial-typography-heading-level-2 {
+						font-weight: normal;
+						margin: 0;
+						color: #33302e;
+						font-family: MetricWeb, sans-serif;
+						font-size: 28px;
+						line-height: 32px;
+						font-weight: 600;
+					}
+				}
+			}
+		}
+	}
+
 	@include describe('oEditorialTypographyTag') {
 
 		@include test('Styles non-link topic tags') {

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -8,12 +8,12 @@
 				}
 				@include contains($selector: false) {
 					.o-editorial-typography-heading-level-1 {
-						font-weight: normal;
 						margin: 0;
 						color: #33302e;
 						font-family: FinancierDisplayWeb, serif;
 						font-size: 28px;
 						line-height: 32px;
+						font-weight: 400;
 					}
 				}
 			}
@@ -26,16 +26,15 @@
 				}
 				@include contains($selector: false) {
 					.o-editorial-typography-heading-level-1 {
-						font-weight: normal;
 						margin: 0;
 						color: #33302e;
 						font-family: FinancierDisplayWeb, serif;
 						font-size: 28px;
 						line-height: 32px;
+						font-weight: 400;
 					}
 
 					.o-editorial-typography-heading-level-2 {
-						font-weight: normal;
 						margin: 0;
 						color: #33302e;
 						font-family: MetricWeb, sans-serif;


### PR DESCRIPTION
This previously errored:

```scss
@include oEditorialTypography($opts: (
    'headings': (1)
));
```
>The "headings" option must be a list of heading levels to include e.g. `(1, 2, 3, 4, 5)`.

That's because
```scss
$a: type-of((1)) // number
$a: type-of((1,)) // list
```

Issue:
https://github.com/Financial-Times/o-editorial-typography/issues/13

Relates to:
https://github.com/Financial-Times/o-typography/pull/242