### PR TITLE
Update the default standfirst colour from black-60 to black-80

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -106,7 +106,7 @@
 /// Output styles for editorial standfirst.
 @mixin oEditorialTypographyStandfirst() {
 	@include oTypographySans($scale: 2);
-	color: oColorsByName('black-60');
+	color: oColorsByName('black-80');
 }
 
 /// Output styles for the editorial byline.


### PR DESCRIPTION
Standfirsts in o-topper do not use o-editorial-typography for
colour, as toppers and their standfirst may be many colours:

https://github.com/Financial-Times/o-topper/blob/fc7ab45674ab6a6b2b74c5b9459e34912f16ef4e/src/scss/_mixins.scss#L279

So o-topper sets 80% on the themes text colour, whatever that is:
https://github.com/Financial-Times/o-topper/blob/0e0ff7997feb1dc0e8320d3cd9f72f3fb47fa3d4/src/scss/_elements.scss#L3

This commit brings the o-editorial-typography default standfirst
style inline with o-topper.