### PR TITLE
Backport: Update o-editorial-typography h4 for a "features xhead" heading

### DIFF
--- a/demos/src/headings.mustache
+++ b/demos/src/headings.mustache
@@ -1,5 +1,5 @@
-<h1 class="o-editorial-typography-heading-level-1">Heading level 1 &mdash; Don&rsquo;t settle for black and white</h1>
-<h2 class="o-editorial-typography-heading-level-2">Heading level 2 &mdash; Don&rsquo;t settle for black and white</h2>
-<h3 class="o-editorial-typography-heading-level-3">Heading level 3 &mdash; Don&rsquo;t settle for black and white</h3>
-<h4 class="o-editorial-typography-heading-level-4">Heading level 4 &mdash; Don&rsquo;t settle for black and white</h4>
-<h5 class="o-editorial-typography-heading-level-5">Heading level 5 &mdash; Don&rsquo;t settle for black and white</h5>
+<h1 class="o-editorial-typography-heading-level-1">Headline (h1) &mdash; Don&rsquo;t settle for black and white</h1>
+<h2 class="o-editorial-typography-heading-level-2">Chapter (h2) &mdash; Don&rsquo;t settle for black and white</h2>
+<h3 class="o-editorial-typography-heading-level-3">Subhead (h3) &mdash; Don&rsquo;t settle for black and white</h3>
+<h4 class="o-editorial-typography-heading-level-4">Features xhead (h4) &mdash; Don&rsquo;t settle for black and white</h4>
+<h5 class="o-editorial-typography-heading-level-5">Label (h5) &mdash; Don&rsquo;t settle for black and white</h5>

--- a/demos/src/headline.mustache
+++ b/demos/src/headline.mustache
@@ -1,1 +1,1 @@
-<h1 class="o-editorial-typography-headline">Don&rsquo;t settle for black and white</h1>
+<h1 class="o-editorial-typography-headline">Headline Large (h1) &mdash; Don&rsquo;t settle for black and white</h1>

--- a/origami.json
+++ b/origami.json
@@ -27,7 +27,7 @@
 	},
 	"demos": [
 		{
-			"title": "Headline",
+			"title": "Headline Large",
 			"name": "headline",
 			"template": "demos/src/headline.mustache"
 		},

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -104,7 +104,7 @@
 	}
 
 	@if($level == 4) {
-		@include oTypographySans($scale: 3, $weight: 'regular');
+		@include oTypographyDisplay($scale: 4, $weight: 'bold');
 	}
 
 	@if($level == 5) {


### PR DESCRIPTION
See: https://github.com/Financial-Times/origami/pull/324